### PR TITLE
Fix cargo warnings

### DIFF
--- a/src/ast/interpreter.rs
+++ b/src/ast/interpreter.rs
@@ -106,8 +106,6 @@ mod tests {
     }
 
     fn assert_parse_interpret(program: &[u8], input: &str, output: &str) {
-        use super::super::parser::parse_program;
-
         let program = parse_program(program).unwrap();
         assert_interpret(&*program, input.as_bytes(), output.as_bytes());
     }

--- a/src/rts.rs
+++ b/src/rts.rs
@@ -25,9 +25,9 @@ pub const OVERFLOW: u64  = 2;
 /// Trait objects providing channels for standard input and output.
 pub struct RtsState<'a> {
     /// Input channel for the `,` operation.
-    input:  &'a mut Read,
+    input:  &'a mut dyn Read,
     /// Output channel for the `.` operation.
-    output: &'a mut Write,
+    output: &'a mut dyn Write,
 }
 
 impl<'a> RtsState<'a> {


### PR DESCRIPTION
This pull requests fixes the warnings produced by cargo by adding the `dyn` keyword to trait objects and removing a duplicate import.